### PR TITLE
cli: Fix missing backticks in GitHub issue code fence formatting

### DIFF
--- a/src/services/llm.service.ts
+++ b/src/services/llm.service.ts
@@ -71,23 +71,19 @@ Respond with ONLY a valid JSON object with "title" and "body" fields. No markdow
     // before the actual JSON object when acting as an agent.
     let structured: StructuredIssue;
     try {
-      // Strip markdown code fences if present
-      const cleaned = responseText
-        .replace(/```(?:json)?\s*\n?/g, '')
-        .replace(/\n?```/g, '')
-        .trim();
-
-      // Try parsing the whole thing first (fast path)
+      // Try parsing the whole response first (fast path)
       try {
-        structured = JSON.parse(cleaned) as StructuredIssue;
+        structured = JSON.parse(responseText.trim()) as StructuredIssue;
       } catch {
+        // Response may have markdown code fences or preamble text
         // Find the first { ... } JSON object in the response
-        const jsonStart = cleaned.indexOf('{');
-        const jsonEnd = cleaned.lastIndexOf('}');
+        const jsonStart = responseText.indexOf('{');
+        const jsonEnd = responseText.lastIndexOf('}');
         if (jsonStart === -1 || jsonEnd === -1 || jsonEnd <= jsonStart) {
           throw new Error('No JSON object found in response');
         }
-        structured = JSON.parse(cleaned.substring(jsonStart, jsonEnd + 1)) as StructuredIssue;
+        const jsonText = responseText.substring(jsonStart, jsonEnd + 1);
+        structured = JSON.parse(jsonText) as StructuredIssue;
       }
     } catch (error) {
       throw new Error(
@@ -139,7 +135,12 @@ Technical specifics of WHAT to build. Be prescriptive. Specify:
 - Function/class names to add or change
 - Type signatures or interfaces needed
 - Key data structures or algorithms
-- Pseudocode or code snippets for complex algorithms, non-obvious logic, or tricky edge cases
+- Code snippets for complex algorithms, non-obvious logic, or tricky edge cases
+
+When including code examples, ALWAYS use proper markdown code fences with triple backticks and language identifier:
+\`\`\`typescript
+// example code here
+\`\`\`
 
 Be as specific as possible based on the raw description. When details are unclear:
 - State your assumptions explicitly (e.g., "Assuming JWT-based auth with refresh tokens")
@@ -189,6 +190,7 @@ ANTI-SLOP RULES — strictly follow these:
 - No emoji anywhere
 - No numbered lists with "Step 1:", "Step 2:" in prose sections (use bullets or narrative)
 - No sections beyond the eight listed above
+- ALWAYS use proper markdown code fences: \`\`\`language for opening and \`\`\` for closing — never output just "typescript" or "javascript" without the backticks
 - Target 400-800 words for medium-to-large features (fewer is fine for small changes)
 - Write like a senior engineer talking to another senior engineer
 - Be concrete and prescriptive — the AI agent needs zero ambiguity`;

--- a/tests/commands/create-issue.command.test.ts
+++ b/tests/commands/create-issue.command.test.ts
@@ -325,5 +325,64 @@ describe('CreateIssueCommand', () => {
 
       expect(mockLogger.error).toHaveBeenCalledWith(`Failed to create issue: ${mockError.message}`);
     });
+
+    it('creates issue with proper code fence formatting', async () => {
+      const mockDescription = 'Add authentication with code examples';
+      const mockStructured = {
+        title: 'feat: Add authentication',
+        body: `## Implementation Details
+
+Create an authentication service:
+
+\`\`\`typescript
+export class AuthService {
+  async login(username: string, password: string) {
+    return jwt.sign({ username }, SECRET);
+  }
+}
+\`\`\`
+
+## Testing Strategy
+- Test login flow with valid credentials`,
+      };
+      const mockIssueNumber = 42;
+      const mockRepoName = 'owner/repo';
+
+      const mockRL = {
+        on: vi.fn((event, callback) => {
+          if (event === 'line') {
+            callback(mockDescription);
+          }
+          if (event === 'close') {
+            callback();
+          }
+          return mockRL;
+        }),
+        close: vi.fn(),
+        question: vi.fn((question, answerCallback) => {
+          answerCallback('y');
+        }),
+      };
+      vi.mocked(readline.createInterface).mockReturnValue(mockRL as any);
+      vi.spyOn(process, 'once').mockImplementation(() => process as any);
+      vi.spyOn(process, 'removeListener').mockImplementation(() => process as any);
+
+      mockLLMService.isAvailable.mockResolvedValue(true);
+      mockLLMService.structureIssue.mockResolvedValue(mockStructured);
+      vi.mocked(mockGitHub.createIssue).mockResolvedValue(mockIssueNumber);
+      vi.mocked(mockGitHub.repoName).mockResolvedValue(mockRepoName);
+
+      await command.execute();
+
+      expect(mockGitHub.createIssue).toHaveBeenCalledWith({
+        title: mockStructured.title,
+        body: mockStructured.body,
+      });
+
+      const issueBody = vi.mocked(mockGitHub.createIssue).mock.calls[0][0].body;
+      expect(issueBody).toContain('```typescript');
+      expect(issueBody).toMatch(/```typescript[\s\S]*?```/);
+      expect(issueBody).not.toMatch(/^typescript$/m);
+    });
   });
 });

--- a/tests/services/llm.service.test.ts
+++ b/tests/services/llm.service.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { LLMService, StructuredIssue } from '../../src/services/llm.service.js';
+import { CodeAgent } from '../../src/services/agents/base.agent.js';
+
+describe('LLMService', () => {
+  let llmService: LLMService;
+  let mockAgent: CodeAgent;
+
+  beforeEach(() => {
+    mockAgent = {
+      isAvailable: vi.fn(),
+      checkAuth: vi.fn(),
+      prompt: vi.fn(),
+      waitForCompletion: vi.fn(),
+    } as any;
+
+    llmService = new LLMService(mockAgent);
+  });
+
+  describe('isAvailable', () => {
+    it('returns true when agent is available', async () => {
+      vi.mocked(mockAgent.isAvailable).mockResolvedValue(true);
+
+      const result = await llmService.isAvailable();
+
+      expect(result).toBe(true);
+      expect(mockAgent.isAvailable).toHaveBeenCalled();
+    });
+
+    it('returns false when agent is not available', async () => {
+      vi.mocked(mockAgent.isAvailable).mockResolvedValue(false);
+
+      const result = await llmService.isAvailable();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('structureIssue', () => {
+    beforeEach(() => {
+      vi.mocked(mockAgent.checkAuth).mockResolvedValue({
+        authenticated: true,
+        error: null,
+      });
+    });
+
+    it('throws error when agent is not authenticated', async () => {
+      vi.mocked(mockAgent.checkAuth).mockResolvedValue({
+        authenticated: false,
+        error: 'API key not set',
+      });
+
+      await expect(
+        llmService.structureIssue('Add authentication')
+      ).rejects.toThrow('API key not set');
+    });
+
+    it('throws error when agent does not support prompt method', async () => {
+      const agentWithoutPrompt = {
+        isAvailable: vi.fn(),
+        checkAuth: vi.fn().mockResolvedValue({ authenticated: true, error: null }),
+        waitForCompletion: vi.fn(),
+      } as any;
+
+      const service = new LLMService(agentWithoutPrompt);
+
+      await expect(
+        service.structureIssue('Add authentication')
+      ).rejects.toThrow('Agent does not support the prompt() method');
+    });
+
+    it('parses valid JSON response from agent', async () => {
+      const mockResponse = JSON.stringify({
+        title: 'feat: Add user authentication',
+        body: 'Implementation details here',
+      });
+      vi.mocked(mockAgent.prompt).mockResolvedValue(mockResponse);
+
+      const result = await llmService.structureIssue('Add authentication');
+
+      expect(result).toEqual({
+        title: 'feat: Add user authentication',
+        body: 'Implementation details here',
+      });
+    });
+
+    it('strips markdown code fences from response', async () => {
+      const mockResponse = '```json\n{"title": "Add auth", "body": "Details"}\n```';
+      vi.mocked(mockAgent.prompt).mockResolvedValue(mockResponse);
+
+      const result = await llmService.structureIssue('Add authentication');
+
+      expect(result).toEqual({
+        title: 'Add auth',
+        body: 'Details',
+      });
+    });
+
+    it('extracts JSON from response with preamble text', async () => {
+      const mockResponse = 'Sure, here is the structured issue:\n{"title": "Add auth", "body": "Details"}';
+      vi.mocked(mockAgent.prompt).mockResolvedValue(mockResponse);
+
+      const result = await llmService.structureIssue('Add authentication');
+
+      expect(result).toEqual({
+        title: 'Add auth',
+        body: 'Details',
+      });
+    });
+
+    it('throws error when response has no JSON', async () => {
+      vi.mocked(mockAgent.prompt).mockResolvedValue('This is just text without JSON');
+
+      await expect(
+        llmService.structureIssue('Add authentication')
+      ).rejects.toThrow('Failed to parse structured issue response');
+    });
+
+    it('throws error when title is empty', async () => {
+      const mockResponse = JSON.stringify({
+        title: '',
+        body: 'Details',
+      });
+      vi.mocked(mockAgent.prompt).mockResolvedValue(mockResponse);
+
+      await expect(
+        llmService.structureIssue('Add authentication')
+      ).rejects.toThrow('LLM returned an empty title');
+    });
+
+    it('throws error when body is empty', async () => {
+      const mockResponse = JSON.stringify({
+        title: 'Add auth',
+        body: '',
+      });
+      vi.mocked(mockAgent.prompt).mockResolvedValue(mockResponse);
+
+      await expect(
+        llmService.structureIssue('Add authentication')
+      ).rejects.toThrow('LLM returned an empty body');
+    });
+
+    it('truncates title exceeding GitHub limit', async () => {
+      const longTitle = 'a'.repeat(300);
+      const mockResponse = JSON.stringify({
+        title: longTitle,
+        body: 'Details',
+      });
+      vi.mocked(mockAgent.prompt).mockResolvedValue(mockResponse);
+
+      const result = await llmService.structureIssue('Add authentication');
+
+      expect(result.title.length).toBe(256);
+      expect(result.title).toMatch(/\.\.\.$/);
+    });
+
+    it('builds prompt with code fence instructions', async () => {
+      const mockResponse = JSON.stringify({
+        title: 'Add auth',
+        body: 'Details',
+      });
+      vi.mocked(mockAgent.prompt).mockResolvedValue(mockResponse);
+
+      await llmService.structureIssue('Add authentication');
+
+      expect(mockAgent.prompt).toHaveBeenCalled();
+      const promptArg = vi.mocked(mockAgent.prompt).mock.calls[0][0];
+
+      // Verify prompt includes instructions for proper code fences
+      expect(promptArg).toContain('ALWAYS use proper markdown code fences with triple backticks and language identifier');
+      expect(promptArg).toContain('```typescript');
+      expect(promptArg).toContain('ALWAYS use proper markdown code fences: ```language for opening and ``` for closing');
+    });
+
+    it('generates body with proper code fence formatting when LLM responds correctly', async () => {
+      const bodyWithCodeFence = `## Implementation Details
+Create a new authentication service.
+
+\`\`\`typescript
+export class AuthService {
+  async login(username: string, password: string) {
+    // implementation
+  }
+}
+\`\`\`
+
+## Testing Strategy
+- Test login flow
+- Test invalid credentials`;
+
+      const mockResponse = JSON.stringify({
+        title: 'feat: Add authentication service',
+        body: bodyWithCodeFence,
+      });
+      vi.mocked(mockAgent.prompt).mockResolvedValue(mockResponse);
+
+      const result = await llmService.structureIssue('Add user authentication with JWT');
+
+      expect(result.body).toContain('```typescript');
+      expect(result.body).toContain('```');
+      expect(result.body).toMatch(/```typescript[\s\S]*?```/);
+    });
+
+    it('prompt explicitly forbids outputting language name without backticks', async () => {
+      const mockResponse = JSON.stringify({
+        title: 'Add auth',
+        body: 'Details',
+      });
+      vi.mocked(mockAgent.prompt).mockResolvedValue(mockResponse);
+
+      await llmService.structureIssue('Add authentication');
+
+      const promptArg = vi.mocked(mockAgent.prompt).mock.calls[0][0];
+      expect(promptArg).toContain('never output just "typescript" or "javascript" without the backticks');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

## Problem / Motivation

Closes #7

## What Changed

- 160b1d9 fix: Add explicit code fence formatting instructions to LLM prompt (#7)

## Why

See issue #7 for full details.

## How to Test

Strategy

- Add or update tests in `tests/commands/create-issue.command.test.ts`
- Test case: verify generated markdown string contains `\`\`\`typescript` for TypeScript code blocks
- Test case: verify generated markdown string contains `\`\`\`javascript` for JavaScript code blocks  
- Test case: verify code fence closing delimiter `\`\`\`` is present
- Manual verification: run `rig create-issue` locally, view the created issue on GitHub, and confirm code blocks render with syntax highlighting

## Acceptance Criteria

- Code blocks in created GitHub issues include proper triple-backtick delimiters (\`\`\`language)
- Code blocks render with syntax highlighting when viewed on GitHub
- Both opening (\`\`\`typescript) and closing (\`\`\`) delimiters are present
- Existing issue creation functionality remains unchanged
- All language identifiers (typescript, javascript, bash, etc.) work correctly with fenced code blocks

---
*Implemented by Claude Code via `rig ship`*
