### PR TITLE
cli: Improve PR body building in pr-template service and add rig skill

### DIFF
--- a/.claude/skills/rig/SKILL.md
+++ b/.claude/skills/rig/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: rig
+description: Use the rig CLI for the GitHub issue-to-PR workflow. Trigger when asked to work on an issue ("do issue 22", "pick up #22"), start a branch for an issue, or open a PR for finished work. Also trigger when asked to create issues or decompose a plan into issues — those flows are interactive and must be handed back to the human.
+---
+
+# rig
+
+rig is a globally installed CLI that runs the GitHub issue-to-PR
+workflow for the current repo. It talks to GitHub through `gh` and uses
+an LLM provider (Kimi/Moonshot by default) for AI text generation. It
+needs the provider's API key in the environment (`MOONSHOT_API_KEY` for
+the default provider) and an authenticated `gh`. Optional config lives
+in `.rig.yml` at the repo root.
+
+## Commands you can run
+
+### Start work on issue N
+
+```bash
+rig branch 22
+```
+
+- Creates `<type>/issue-22-<slug>` off the latest remote base branch
+  and pushes it to origin. The type comes from the issue's type label
+  (`bug` → `fix`, `feature` → `feat`). The slug is AI-generated.
+- If a branch for the issue already exists, it switches to it instead.
+- Never invent branch names by hand. `rig pr` parses the issue number
+  from the branch name, so the `issue-<n>` segment must be exact.
+
+Then read the issue content directly:
+
+```bash
+gh issue view 22
+```
+
+(`rig grab 22` copies the issue to the clipboard — that is for humans
+pasting into a chat, not for you. Use `gh issue view`.)
+
+### Open or update the PR
+
+After implementing and committing on the issue branch:
+
+```bash
+rig pr
+```
+
+- Pushes the branch, then creates or updates the PR. The body is
+  generated from the issue sections and the commit log — do not write
+  a PR body yourself.
+- It refuses to run on the base branch (`master`/`main`). If the
+  branch name has no issue number, pass `--issue 22`.
+- Rerunning it is safe: it updates the existing PR.
+
+### File an issue
+
+Write the raw description to a file, then:
+
+```bash
+rig create-issue --file /tmp/issue.md --yes
+```
+
+The AI structures the description into a titled, labeled issue and
+files it. Do not pre-structure the file into sections — write plain
+prose and let rig do the structuring. Do not substitute
+`gh issue create`.
+
+### Decompose a plan into issues
+
+Write the full spec/PRD to a file, then:
+
+```bash
+rig story --file /tmp/spec.md --yes
+```
+
+Creates a parent story issue plus atomic child issues. Use this for
+multi-issue plans; use `create-issue` for a single piece of work.
+
+### One-time repo setup
+
+```bash
+rig setup-labels
+```
+
+Creates rig's label set. Safe to rerun.
+
+## Rules
+
+- Never run `rig create-issue` or `rig story` WITHOUT `--file` and
+  `--yes`: the interactive forms read from the terminal and will hang
+  or self-cancel under an agent.
+- `--yes` files issues without a human preview. Only use it when the
+  human asked you to create the issue(s); otherwise show them the
+  description first.
+
+## The full loop
+
+1. Issues are filed with `rig create-issue` or `rig story`
+   (by the human, or by you with `--file`/`--yes` when asked).
+2. You: `rig branch <n>` → `gh issue view <n>` → implement → commit
+   (follow the repo's commit conventions) → `rig pr`.
+3. Human reviews and merges the PR.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ verbose: false
 
 ---
 
+## Claude Code skill
+
+The repo ships an agent-facing skill at [`.claude/skills/rig/SKILL.md`](./.claude/skills/rig/SKILL.md) that teaches Claude Code the rig workflow: which commands to run for "pick up issue 22" or "open a PR", and which flags (`--file`, `--yes`) keep the interactive commands from hanging under an agent. Copy the `rig` folder into your own project's `.claude/skills/` directory to use it there.
+
+---
+
 ## AI Providers
 
 **Kimi** (default): Moonshot AI's Kimi models over the OpenAI-compatible chat-completions API. Requires `MOONSHOT_API_KEY`. Defaults to `kimi-k3`; override with `agent.model` in `.rig.yml`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rig-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rig-cli",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rig-cli",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "AI-assisted GitHub issue creation and PR opening. Plan to issue, branch to PR; you implement with your own tools.",
   "type": "module",
   "bin": {

--- a/src/services/llm.service.ts
+++ b/src/services/llm.service.ts
@@ -224,7 +224,7 @@ RULES:
 - Each issue must be small and focused — one concern per issue.
 - Order issues by implementation dependency (foundational work first).
 - Every issue body must start with "Parent story: #${parentIssueNumber}" on the first line, followed by a blank line.
-- Use the same issue body format: ## Problem / Motivation, ## Implementation Details, ## Testing Strategy, ## Acceptance Criteria. Skip sections that don't apply.
+- Use the same issue body format: ## Problem / Motivation (2 paragraphs max), ## Implementation Details, ## Testing Strategy, ## Acceptance Criteria. Skip sections that don't apply.
 - Titles: imperative, 50-80 chars, with component prefix if clear (cli: / api: / ui: / etc.)
 - No filler prose. Senior engineer to senior engineer tone.
 ${styleSection}
@@ -347,7 +347,7 @@ TITLE:
 BODY — Use exactly these H2 sections in order. Skip a section entirely if it does not apply:
 
 ## Problem / Motivation
-Concrete symptom or gap in 2-3 sentences.
+Concrete symptom or gap — what this solves or helps fix. 2 paragraphs max; this section is reused verbatim in the PR body.
 
 ## Implementation Details
 WHAT to build. Be prescriptive:

--- a/src/services/pr-template.service.ts
+++ b/src/services/pr-template.service.ts
@@ -47,6 +47,9 @@ export class PrTemplateService {
     // Build issue context (acceptance criteria or implementation section)
     const issueContext = this.extractContext(issue.body || '', issueNumber);
 
+    // Build the short "what this solves" explanation from the issue
+    const issueProblem = this.extractProblem(issue.body || '', issueNumber);
+
     // Get commit log
     const commitLog = await this.git.logVsMaster();
     const formattedCommitLog = commitLog
@@ -71,6 +74,7 @@ export class PrTemplateService {
       issue_number: issueNumber,
       issue_summary: issueSummary,
       issue_context: issueContext,
+      issue_problem: issueProblem,
       commit_log: formattedCommitLog || '- No commits',
       manual_test_steps: manualTestSteps,
     };
@@ -94,7 +98,7 @@ export class PrTemplateService {
 
     // First, look for an explicit "Summary", "Description", or "Overview" section
     const summaryMatch = body.match(
-      /(###?\s+(Summary|Description|Overview)[\s\S]*?)(?=\n###|$)/i
+      /(###?\s+(Summary|Description|Overview)[\s\S]*?)(?=\n##|$)/i
     );
 
     if (summaryMatch) {
@@ -111,11 +115,52 @@ export class PrTemplateService {
       }
     }
 
-    // Fallback: Get first paragraph (up to first empty line)
+    // Fallback: Get first paragraph (up to first empty line). A body that
+    // opens with some other heading has no summary prose — use the title,
+    // so the heading text is not swallowed into the Summary section.
     const firstParagraph = body.split('\n\n')[0];
+    if (/^\s*#/.test(firstParagraph)) {
+      return title;
+    }
     const lines = firstParagraph.split('\n').slice(0, 5);
 
     return lines.join('\n').trim() || title;
+  }
+
+  /**
+   * Extracts a short explanation of what the issue solves or helps fix.
+   *
+   * Prefers the issue's Problem / Motivation section (rig-structured issues
+   * always have one — the issue-writing prompt directs the LLM to keep it
+   * to two paragraphs, so the section is used whole); falls back to the
+   * prose before the first heading.
+   *
+   * @private
+   * @param body - Issue body text
+   * @param issueNumber - Issue number (for fallback message)
+   * @returns Explanation text
+   */
+  private extractProblem(body: string, issueNumber: number): string {
+    const fallback = `See issue #${issueNumber} for the problem this change addresses.`;
+    if (!body) {
+      return fallback;
+    }
+
+    // Prefer an explicit problem/motivation-style section
+    const problemMatch = body.match(
+      /#{2,3}\s+(?:Problem(?:\s*\/\s*Motivation)?|Motivation|Background|Context)[^\n]*\n([\s\S]*?)(?=\n#{1,3}\s|$)/i
+    );
+
+    // Fall back to the prose before the first heading; a body that opens
+    // with some other heading has no leading prose to use
+    const source = problemMatch
+      ? problemMatch[1]
+      : /^\s*#{1,3}\s/.test(body)
+        ? ''
+        : body.split(/\n#{1,3}\s/)[0];
+
+    const trimmed = source.trim();
+    return trimmed.length > 0 ? trimmed : fallback;
   }
 
   /**
@@ -131,9 +176,10 @@ export class PrTemplateService {
       return `See issue #${issueNumber} for full details.`;
     }
 
-    // Look for "Acceptance Criteria" section (include heading)
+    // Look for "Acceptance Criteria" section (include heading; H2 or H3 —
+    // rig-structured issues use H2 sections)
     const acceptanceCriteriaMatch = body.match(
-      /(### Acceptance Criteria[\s\S]*?)(?=\n###|$)/i
+      /(#{2,3} Acceptance Criteria[\s\S]*?)(?=\n##|$)/i
     );
     if (acceptanceCriteriaMatch) {
       return acceptanceCriteriaMatch[1].trim().split('\n').slice(0, 15).join('\n');
@@ -141,7 +187,7 @@ export class PrTemplateService {
 
     // Look for "Implementation" section (include heading)
     const implementationMatch = body.match(
-      /(### Implementation[\s\S]*?)(?=\n###|$)/i
+      /(#{2,3} Implementation[\s\S]*?)(?=\n##|$)/i
     );
     if (implementationMatch) {
       return implementationMatch[1].trim().split('\n').slice(0, 15).join('\n');

--- a/src/templates/pr-body.md
+++ b/src/templates/pr-body.md
@@ -4,6 +4,10 @@
 
 Closes #{{issue_number}}
 
+## What This Solves
+
+{{issue_problem}}
+
 ## What Changed
 
 {{commit_log}}

--- a/tests/services/pr-template.service.test.ts
+++ b/tests/services/pr-template.service.test.ts
@@ -61,6 +61,7 @@ describe('PrTemplateService', () => {
       expect(vars.issue_context).toContain('Users can log in');
       expect(vars.commit_log).toBe('- abc123 Initial commit\n- def456 Add tests');
       expect(vars.manual_test_steps).toBeDefined();
+      expect(vars.issue_problem).toBeDefined();
     });
 
     it('handles empty commit log', async () => {
@@ -89,6 +90,17 @@ describe('PrTemplateService', () => {
       expect(vars.issue_summary).not.toContain('Second paragraph');
     });
 
+    it('returns title when body opens with a non-summary heading', async () => {
+      await service.generatePrBody(
+        makeIssue({
+          title: 'Fix session expiry',
+          body: '## Problem / Motivation\nSessions expire too fast.',
+        })
+      );
+
+      expect(renderedVars().issue_summary).toBe('Fix session expiry');
+    });
+
     it('limits summary to first 5 lines', async () => {
       await service.generatePrBody(
         makeIssue({ body: 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5\nLine 6\nLine 7' })
@@ -97,6 +109,79 @@ describe('PrTemplateService', () => {
       const vars = renderedVars();
       expect(vars.issue_summary).toBe('Line 1\nLine 2\nLine 3\nLine 4\nLine 5');
       expect(vars.issue_summary).not.toContain('Line 6');
+    });
+  });
+
+  describe('extractProblem', () => {
+    it('returns fallback when body is empty', async () => {
+      await service.generatePrBody(makeIssue({ number: 10, body: '' }));
+
+      expect(renderedVars().issue_problem).toBe(
+        'See issue #10 for the problem this change addresses.'
+      );
+    });
+
+    it('extracts the Problem / Motivation section', async () => {
+      await service.generatePrBody(
+        makeIssue({
+          body: `## Problem / Motivation
+Login sessions expire after 5 minutes, logging users out mid-task.
+
+## Implementation Details
+Bump the session TTL.`,
+        })
+      );
+
+      const vars = renderedVars();
+      expect(vars.issue_problem).toBe(
+        'Login sessions expire after 5 minutes, logging users out mid-task.'
+      );
+      expect(vars.issue_problem).not.toContain('Implementation');
+    });
+
+    it('uses the whole problem section without truncation', async () => {
+      await service.generatePrBody(
+        makeIssue({
+          body: `## Problem / Motivation
+Paragraph one.
+
+Paragraph two.
+
+Paragraph three.
+
+## Acceptance Criteria
+- Done`,
+        })
+      );
+
+      expect(renderedVars().issue_problem).toBe(
+        'Paragraph one.\n\nParagraph two.\n\nParagraph three.'
+      );
+    });
+
+    it('falls back to prose before the first heading', async () => {
+      await service.generatePrBody(
+        makeIssue({
+          body: `The CLI crashes on startup when the config file is missing.
+
+## Implementation Details
+Add a guard.`,
+        })
+      );
+
+      expect(renderedVars().issue_problem).toBe(
+        'The CLI crashes on startup when the config file is missing.'
+      );
+    });
+
+    it('returns fallback when the body has headings but no leading prose or problem section', async () => {
+      await service.generatePrBody(
+        makeIssue({ number: 14, body: `## Implementation Details\nAdd a guard.` })
+      );
+
+      expect(renderedVars().issue_problem).toBe(
+        'See issue #14 for the problem this change addresses.'
+      );
     });
   });
 
@@ -127,6 +212,26 @@ Some implementation notes`,
       expect(vars.issue_context).toContain('Users can login');
       expect(vars.issue_context).toContain('Sessions persist');
       expect(vars.issue_context).not.toContain('Implementation');
+    });
+
+    it('extracts H2 Acceptance Criteria section (rig-structured issues)', async () => {
+      await service.generatePrBody(
+        makeIssue({
+          body: `## Problem / Motivation
+Something is broken.
+
+## Acceptance Criteria
+- Users can login
+
+## Notes
+Extra notes`,
+        })
+      );
+
+      const vars = renderedVars();
+      expect(vars.issue_context).toContain('## Acceptance Criteria');
+      expect(vars.issue_context).toContain('Users can login');
+      expect(vars.issue_context).not.toContain('Extra notes');
     });
 
     it('extracts Implementation section if no Acceptance Criteria', async () => {


### PR DESCRIPTION
## Summary

## Problem / Motivation
The pr-template service inserts issue content raw and dumps the commit log as a flat list, leaving pr-body template placeholders unfilled or noisy. The llm service prompt does not receive structured input, so generated summaries are unreliable. Separately, no Claude Code skill documents the rig issue-to-PR workflow, so agents invoke the CLI interactively and block.

Closes #27

## What Changed

- bdb9626 feat: rig pr improvements, add rig skill

## Why

See issue #27 for full details.

## How to Test

Strategy
Unit tests in test/services/pr-template.service.test.ts with llm.service mocked:
- parseIssueSections extracts all H2 sections and trims whitespace
- sections absent from the issue are omitted from the rendered body, not rendered as empty headings or "undefined"
- groupCommits buckets feat/fix/chore correctly, handles scoped prefixes (feat(cli): ...), and routes non-conventional messages to 'other'
- empty commit log renders a body with no Changes section
- LLM success injects the summary; LLM failure falls back to the grouped commit list
- rendered body matches a snapshot of pr-body.md with representative fixtures

## Acceptance Criteria
- PR body contains Summary, parsed issue sections, and commits grouped by type
- No "undefined", empty headings, or raw issue dumps for fixtures with missing sections
- llm.service receives structured { sections, commits } input; fallback path is test-covered
- New test file passes; existing suite unbroken
- .claude/skills/rig/SKILL.md exists with valid frontmatter and documents rig branch, rig pr, rig create-issue, and rig story plus non-interactive rules
- README links to the skill file
- package.json version bumped (minor)

## Notes
Edge cases: duplicate H2 headings in an issue (last wins — document the choice), CRLF line endings in issue bodies, commits with scope prefixes. Keep SKILL.md concise; Claude Code loads it into context on every invocation.

## Questions for Developer
- What specifically is wrong with current PR body output — missing sections, ordering, or summary quality? The rendering rules above assume section parsing plus grouped commits; confirm scope.
- Do rig commands already support non-interactive flags (--yes / --non-interactive), or should the skill only mandate passing all arguments explicitly?
