### PR TITLE
docs: remove Kimi/Moonshot references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Create `.rig.yml` in your project root. All fields are optional; missing values 
 
 ```yaml
 agent:
-  provider: groq     # 'groq' (Groq API, default) or 'kimi' (Moonshot API)
+  provider: groq     # Groq API (default)
   model: openai/gpt-oss-120b  # model ID to request (default: provider-specific)
   timeout: 120       # seconds per AI call
 
@@ -130,13 +130,6 @@ The repo ships an agent-facing skill at [`.claude/skills/rig/SKILL.md`](./.claud
 
 **Groq** (default): Groq's hosted open models over the OpenAI-compatible chat-completions API. Requires `GROQ_API_KEY`. Defaults to `openai/gpt-oss-120b`; override with `agent.model` in `.rig.yml`.
 
-**Kimi**: Moonshot AI's Kimi models over the OpenAI-compatible chat-completions API. Requires `MOONSHOT_API_KEY`. Defaults to `kimi-k3`. Opt in with:
-
-```yaml
-agent:
-  provider: kimi
-```
-
 Providers are small subclasses of `OpenAICompatProvider` (`src/services/llm-provider.ts`) — adding another vendor is a name, base URL, API-key env var, and default model.
 
 AI is used only for text generation — issue bodies and spec decomposition. rig never runs an agent on your code.
@@ -145,7 +138,7 @@ AI is used only for text generation — issue bodies and spec decomposition. rig
 
 ## Disclaimer
 
-rig-cli is an unofficial third-party tool created by Zach Stecko. Not affiliated with or endorsed by Groq or Moonshot AI. You must have your own API key and comply with your model provider's terms of service.
+rig-cli is an unofficial third-party tool created by Zach Stecko. Not affiliated with or endorsed by Groq. You must have your own API key and comply with your model provider's terms of service.
 
 ## License
 


### PR DESCRIPTION
## Summary

docs: remove Kimi/Moonshot references from README

Closes #34

## What This Solves

The README still contains legacy references to Kimi and Moonshot as AI providers. Since Groq is now the default and only supported provider, these mentions cause confusion for new users and clutter the documentation.

Removing the outdated opt‑in instructions, example configuration comment, and disclaimer phrasing ensures the documentation accurately reflects the current feature set and prevents users from attempting to configure unsupported providers.

## What Changed

- cd4bb12 docs: drop Kimi from README, Groq is the only documented provider
- 11f0d34 llm: Switch default provider from Kimi to Groq (openai/gpt-oss-120b) (#33)
- b6b95f5 chore: bump due to versioning fixes
- b39d334 Merge remote-tracking branch 'origin/release'
- c09daef feat: rig pr improvements, add rig skill (#28)
- ab30e42 chore: versioning, someone has the old rig-cli 1.0.0 already >:(
- 1769639 chore: compliance angle
- 18ceb49 chore: bump version
- 7e8ea27 feat: Strip rig-cli of Automating Pr Creation (#26)
- b4aa7e4 fix: test runner checking for jsx
- 9b1e958 fix: git close issue
- 4e2e4a7 fix: timeout
- a90493d cli: Support configurable baseBranch in .rig.yml for all git operations (#25)
- 82a924f cli: Add  command to decompose planning specs into atomic issues (#23)
- 12130f5 cli: bootstrap command ignores package manager, always uses npm (#18)
- 3f4242b fix: rig labels auto assign
- 6b4e8f5 cli: Auto-assign labels when creating issues via rig create-issue (#13)
- 73bf2e2 feat: reduce verbosity in issue generation prompts (#11) (#12)
- 6b84726 cli: Auto-commit .rig-state updates during review workflow (#10)
- 7cb6b7c fix: Add explicit code fence formatting instructions to LLM prompt (#7) (#8)
- 8918fc1 fix: up timeout
- 7c22ca0 feat: rig init, starting the singularity
- 625525b feat: allow for generic node applications (rig-cli) to be configured
- 1a6c327 fix: wording
- 29db29d chore: readme
- 13df3b1 feat: allow for dynamic timeouts when creating issues with claude, more verbose output for failures with testing and shipping commands
- db9ebf0 fix: bump release (#2)
- 34f3d1e fix: bump release
- af65be9 fix: formatting
- ec28d99 fix: cleanup
- 3acd01b fix: readme cleanup
- 20c8ce8 fix: auto commit approved pr review fixes
- c02a763 feat: option to spawn claude code's binary instead of using the api
- 02adf90 Claude sdk (#1)

## Why

## Acceptance Criteria
- The Kimi opt‑in block is completely removed from the AI Providers section.
- The `.rig.yml` example comment only lists `"groq"` and `"openai"` as provider options.
- The disclaimer sentence no longer contains the phrase "or Moonshot AI".
- Rendering the updated README produces valid markdown with no broken lists or headings.
- No code files other than `README.md` are modified.
- CI passes without new lint or test failures.

## How to Test

Strategy
- Manual verification:
  1. Open `README.md` in a markdown viewer and confirm the Kimi opt‑in section is absent.
  2. Verify the `.rig.yml` example comment no longer lists `"kimi"`.
  3. Check the disclaimer no longer mentions Moonshot AI and reads naturally.
- Automated check (optional): add a CI step that greps the README for the strings `Kimi`, `kimi`, and `Moonshot` and fails if any are found.

## Acceptance Criteria
- The Kimi opt‑in block is completely removed from the AI Providers section.
- The `.rig.yml` example comment only lists `"groq"` and `"openai"` as provider options.
- The disclaimer sentence no longer contains the phrase "or Moonshot AI".
- Rendering the updated README produces valid markdown with no broken lists or headings.
- No code files other than `README.md` are modified.
- CI passes without new lint or test failures.
